### PR TITLE
#155 - fix json body decode

### DIFF
--- a/src/Mapping/Request/BasicEntity.php
+++ b/src/Mapping/Request/BasicEntity.php
@@ -83,7 +83,7 @@ abstract class BasicEntity extends AbstractEntity
 		try {
 			$body = (array) $request->getJsonBody(true);
 		} catch (JsonException $ex) {
-			throw new ClientErrorException('Invalid json data', null, $ex);
+			throw new ClientErrorException('Invalid json data', 400, $ex);
 		}
 
 		return $this->factory($body);

--- a/src/Mapping/Request/BasicEntity.php
+++ b/src/Mapping/Request/BasicEntity.php
@@ -2,9 +2,11 @@
 
 namespace Apitte\Core\Mapping\Request;
 
+use Apitte\Core\Exception\Api\ClientErrorException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Mapping\TReflectionProperties;
 use Apitte\Core\Schema\Endpoint;
+use Nette\Utils\JsonException;
 
 abstract class BasicEntity extends AbstractEntity
 {
@@ -78,7 +80,13 @@ abstract class BasicEntity extends AbstractEntity
 	 */
 	protected function fromBodyRequest(ApiRequest $request): self
 	{
-		return $this->factory((array) $request->getJsonBody(true));
+		try {
+			$body = (array) $request->getJsonBody(true);
+		} catch (JsonException $ex) {
+			throw new ClientErrorException('Invalid json data: ' . $ex->getMessage());
+		}
+
+		return $this->factory($body);
 	}
 
 	/**

--- a/src/Mapping/Request/BasicEntity.php
+++ b/src/Mapping/Request/BasicEntity.php
@@ -83,7 +83,7 @@ abstract class BasicEntity extends AbstractEntity
 		try {
 			$body = (array) $request->getJsonBody(true);
 		} catch (JsonException $ex) {
-			throw new ClientErrorException('Invalid json data: ' . $ex->getMessage());
+			throw new ClientErrorException('Invalid json data', null, $ex);
 		}
 
 		return $this->factory($body);

--- a/tests/cases/Mapping/RequestEntityMapping.phpt
+++ b/tests/cases/Mapping/RequestEntityMapping.phpt
@@ -117,5 +117,5 @@ test(function (): void {
 
 	Assert::exception(function () use ($entity, $bodyRequest): void {
 		$entity = $entity->fromRequest($bodyRequest->withMethod('POST'));
-	}, ClientErrorException::class, 'Invalid json data', RequestAttributes::ATTR_ENDPOINT));
+	}, ClientErrorException::class, 'Invalid json data');
 });

--- a/tests/cases/Mapping/RequestEntityMapping.phpt
+++ b/tests/cases/Mapping/RequestEntityMapping.phpt
@@ -6,6 +6,7 @@
 
 require_once __DIR__ . '/../../bootstrap.php';
 
+use Apitte\Core\Exception\Api\ClientErrorException;
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
@@ -104,4 +105,17 @@ test(function (): void {
 
 		Assert::same(1, $entity->foo);
 	}
+});
+
+// Try mapping invalid json body
+test(function (): void {
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$entity = new NotEmptyEntity();
+
+	$bodyRequest = $request
+		->withBody(Utils::streamFor('invalid-json'));
+
+	Assert::exception(function () use ($entity, $bodyRequest): void {
+		$entity = $entity->fromRequest($bodyRequest->withMethod('POST'));
+	}, ClientErrorException::class, sprintf('Invalid json data: Syntax error', RequestAttributes::ATTR_ENDPOINT));
 });

--- a/tests/cases/Mapping/RequestEntityMapping.phpt
+++ b/tests/cases/Mapping/RequestEntityMapping.phpt
@@ -117,5 +117,5 @@ test(function (): void {
 
 	Assert::exception(function () use ($entity, $bodyRequest): void {
 		$entity = $entity->fromRequest($bodyRequest->withMethod('POST'));
-	}, ClientErrorException::class, sprintf('Invalid json data: Syntax error', RequestAttributes::ATTR_ENDPOINT));
+	}, ClientErrorException::class, 'Invalid json data', RequestAttributes::ATTR_ENDPOINT));
 });


### PR DESCRIPTION
Apitte return status code 400 when request body is not valid json.

Closes #155 