### PR TITLE
Request header parameter fix

### DIFF
--- a/src/Mapping/RequestParameterMapping.php
+++ b/src/Mapping/RequestParameterMapping.php
@@ -57,7 +57,7 @@ class RequestParameterMapping
 			return $request;
 		}
 
-		$headerParameters = $request->getHeaders();
+		$headerParameters = array_change_key_case($request->getHeaders(), CASE_LOWER);
 		$cookieParams = $request->getCookieParams();
 		// Get request parameters from attribute
 		$requestParameters = $request->getAttribute(RequestAttributes::ATTR_PARAMETERS);

--- a/tests/cases/Mapping/RequestParameterMapping.phpt
+++ b/tests/cases/Mapping/RequestParameterMapping.phpt
@@ -255,7 +255,7 @@ final class TestRequestParameterMapping extends TestCase
 			->withAttribute(RequestAttributes::ATTR_PARAMETERS, []);
 
 		$requestWithEmptyHeader = $request->withHeader(
-			'Auth',
+			'auth',
 			[
 				'some',
 				'',
@@ -271,41 +271,25 @@ final class TestRequestParameterMapping extends TestCase
 			400
 		);
 
-		$requestWithHeader = $request->withHeader(
-			'Auth',
-			[
-				'some',
-				'other',
-			]
-		);
+		foreach (['auth', 'Auth'] as $name) {
+			$requestWithHeader = $request->withHeader(
+				$name,
+				[
+					'some',
+					'other',
+				]
+			);
 
-		$headerResponse = $this->requestParameterMapping->map($requestWithHeader, $this->response);
+			$headerResponse = $this->requestParameterMapping->map($requestWithHeader, $this->response);
 
-		Assert::equal(
-			[
-				'some',
-				'other',
-			],
-			$headerResponse->getHeader('Auth')
-		);
-
-		$requestWithHeader = $request->withHeader(
-			'auth',
-			[
-				'some',
-				'other',
-			]
-		);
-
-		$headerResponse = $this->requestParameterMapping->map($requestWithHeader, $this->response);
-
-		Assert::equal(
-			[
-				'some',
-				'other',
-			],
-			$headerResponse->getHeader('auth')
-		);
+			Assert::equal(
+				[
+					'some',
+					'other',
+				],
+				$headerResponse->getHeader($name)
+			);
+		}
 	}
 
 	public function testDatetimeInQuery(): void

--- a/tests/cases/Mapping/RequestParameterMapping.phpt
+++ b/tests/cases/Mapping/RequestParameterMapping.phpt
@@ -255,7 +255,7 @@ final class TestRequestParameterMapping extends TestCase
 			->withAttribute(RequestAttributes::ATTR_PARAMETERS, []);
 
 		$requestWithEmptyHeader = $request->withHeader(
-			'auth',
+			'Auth',
 			[
 				'some',
 				'',
@@ -272,7 +272,7 @@ final class TestRequestParameterMapping extends TestCase
 		);
 
 		$requestWithHeader = $request->withHeader(
-			'auth',
+			'Auth',
 			[
 				'some',
 				'other',
@@ -286,7 +286,7 @@ final class TestRequestParameterMapping extends TestCase
 				'some',
 				'other',
 			],
-			$headerResponse->getHeader('auth')
+			$headerResponse->getHeader('Auth')
 		);
 	}
 

--- a/tests/cases/Mapping/RequestParameterMapping.phpt
+++ b/tests/cases/Mapping/RequestParameterMapping.phpt
@@ -288,6 +288,24 @@ final class TestRequestParameterMapping extends TestCase
 			],
 			$headerResponse->getHeader('Auth')
 		);
+
+		$requestWithHeader = $request->withHeader(
+			'auth',
+			[
+				'some',
+				'other',
+			]
+		);
+
+		$headerResponse = $this->requestParameterMapping->map($requestWithHeader, $this->response);
+
+		Assert::equal(
+			[
+				'some',
+				'other',
+			],
+			$headerResponse->getHeader('auth')
+		);
 	}
 
 	public function testDatetimeInQuery(): void


### PR DESCRIPTION
Header request parameter "X-Auth-Token" should be provided.

`$request->getHeaders()` return headers names with upper letters (e.g. `X-Auth-Token`) and condition on line 135 (https://github.com/contributte/apitte/blob/master/src/Mapping/RequestParameterMapping.php#L135) is false becouse `$headerParameterName` always contains parameter name (e.g. `x-auth-token`) with lower letters. Therefore, I converted everything to lowercase.