### PR TITLE
Fix deprecations of PHP 8.1

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,10 +27,6 @@ parameters:
 		- '#^Parameter \#1 \$haystack of static method Nette\\Utils\\Strings\:\:contains\(\) expects string, string\|false given\.$#'
 		- message: '#^Method Apitte\\Core\\Annotation\\Controller\\OpenApi\:\:purifyDocblock\(\) should return string but returns string\|null\.$#'
 		  path: %currentWorkingDirectory%/src/Core/Annotation/Controller/OpenApi.php
-		- message: '#^Return type \(iterable&Traversable\) of method Apitte\\Core\\Mapping\\Request\\AbstractEntity\:\:getIterator\(\) should be covariant with return type \(Traversable<mixed, mixed>\) of method IteratorAggregate<mixed,mixed>\:\:getIterator\(\)$#'
-		  path: %currentWorkingDirectory%/src/Core/Mapping/Request/AbstractEntity.php
-		- message: '#^Return type \(iterable&Traversable\) of method Apitte\\Core\\Mapping\\Response\\AbstractEntity\:\:getIterator\(\) should be covariant with return type \(Traversable<mixed, mixed>\) of method IteratorAggregate<mixed,mixed>\:\:getIterator\(\)$#'
-		  path: %currentWorkingDirectory%/src/Core/Mapping/Response/AbstractEntity.php
 
 		# Ignore unsage usage of new static()
 		- '#^Unsafe usage of new static\(\)\.$#'

--- a/src/Core/Mapping/Request/AbstractEntity.php
+++ b/src/Core/Mapping/Request/AbstractEntity.php
@@ -4,7 +4,6 @@ namespace Apitte\Core\Mapping\Request;
 
 use ArrayIterator;
 use IteratorAggregate;
-use Traversable;
 
 abstract class AbstractEntity implements IRequestEntity, IteratorAggregate
 {
@@ -15,9 +14,9 @@ abstract class AbstractEntity implements IRequestEntity, IteratorAggregate
 	abstract public function toArray(): array;
 
 	/**
-	 * @return ArrayIterator|Traversable|mixed[]
+	 * @return ArrayIterator<int|string, mixed>
 	 */
-	public function getIterator(): iterable
+	public function getIterator(): ArrayIterator
 	{
 		return new ArrayIterator($this->toArray());
 	}

--- a/src/Core/Mapping/Response/AbstractEntity.php
+++ b/src/Core/Mapping/Response/AbstractEntity.php
@@ -4,7 +4,6 @@ namespace Apitte\Core\Mapping\Response;
 
 use ArrayIterator;
 use IteratorAggregate;
-use Traversable;
 
 abstract class AbstractEntity implements IResponseEntity, IteratorAggregate
 {
@@ -15,9 +14,9 @@ abstract class AbstractEntity implements IResponseEntity, IteratorAggregate
 	abstract public function toArray(): array;
 
 	/**
-	 * @return ArrayIterator|Traversable|mixed[]
+	 * @return ArrayIterator<int|string, mixed>
 	 */
-	public function getIterator(): iterable
+	public function getIterator(): ArrayIterator
 	{
 		return new ArrayIterator($this->toArray());
 	}


### PR DESCRIPTION
`IteratorAggreage:getIterator()` should return `Traversable` since PHP 8.1

Fixes #177 