### PR TITLE
Fix OpenAPI typed properties support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "contributte/middlewares": "^0.10.0",
     "doctrine/annotations": "^1.13",
     "koriym/attributes": "^1.0.2",
-    "nette/utils": "^3.0.3"
+    "nette/utils": "^3.2"
   },
   "require-dev": {
     "mockery/mockery": "^1.1.0",

--- a/tests/fixtures/ResponseEntity/NativeIntersectionEntity.php
+++ b/tests/fixtures/ResponseEntity/NativeIntersectionEntity.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\ResponseEntity;
+
+use ArrayAccess;
+use DateTime; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+
+class NativeIntersectionEntity
+{
+
+	// PHPCS doesn't understand intersections :-(
+	// phpcs:ignore Squiz.WhiteSpace.OperatorSpacing.NoSpaceBeforeAmp, Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfterAmp
+	public DateTime&ArrayAccess $intersection;
+
+}

--- a/tests/fixtures/ResponseEntity/NativeUnionEntity.php
+++ b/tests/fixtures/ResponseEntity/NativeUnionEntity.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\ResponseEntity;
+
+use DateTime;
+
+class NativeUnionEntity
+{
+
+	public string|int $stringOrInt;
+
+	public bool|null $nullableBool;
+
+	public DateTime|int $dateOrInt;
+
+}

--- a/tests/fixtures/ResponseEntity/TypedResponseEntity.php
+++ b/tests/fixtures/ResponseEntity/TypedResponseEntity.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\ResponseEntity;
+
+use DateTime;
+
+class TypedResponseEntity
+{
+
+	public int $int;
+
+	public ?float $nullableFloat;
+
+	public string $string;
+
+	public bool $bool;
+
+	public DateTime $datetime;
+
+	/** @var int */
+	public $phpdocInt;
+
+	// phpcs:ignore
+	public $untypedProperty;
+
+}


### PR DESCRIPTION
Fixed OpenAPI schema generation from typed properties. 

Because it supports unions and pure intersections it needs to bump `nette/utils` to version 3.2.