### PR TITLE
Fix type extraction from `array`/`mixed` native types

### DIFF
--- a/tests/Cases/OpenApi/SchemaDefinition/Entity/EntityAdapterTest.php
+++ b/tests/Cases/OpenApi/SchemaDefinition/Entity/EntityAdapterTest.php
@@ -9,6 +9,7 @@ use DateTimeInterface;
 use Tester\Assert;
 use Tester\TestCase;
 use Tests\Fixtures\ResponseEntity\CompoundResponseEntity;
+use Tests\Fixtures\ResponseEntity\MixedEntity;
 use Tests\Fixtures\ResponseEntity\NativeIntersectionEntity;
 use Tests\Fixtures\ResponseEntity\NativeUnionEntity;
 use Tests\Fixtures\ResponseEntity\SelfReferencingEntity;
@@ -199,6 +200,8 @@ final class EntityAdapterTest extends TestCase
 					'datetime' => ['type' => 'string', 'format' => 'date-time'],
 					'phpdocInt' => ['type' => 'integer'],
 					'untypedProperty' => ['type' => 'string'],
+					'untypedArray' => ['type' => 'array'],
+					'arrayOfInt' => ['type' => 'array', 'items' => ['type' => 'integer']],
 				],
 			],
 			$adapter->getMetadata(TypedResponseEntity::class)
@@ -230,6 +233,18 @@ final class EntityAdapterTest extends TestCase
 							['type' => 'integer'],
 						],
 					],
+					'arrayOrInt' => [
+						'oneOf' => [
+							['type' => 'array'],
+							['type' => 'integer'],
+						],
+					],
+					'strings' => [
+						'oneOf' => [
+							['type' => 'array', 'items' => ['type' => 'string']],
+							['type' => 'string'],
+						],
+					],
 				],
 			],
 			$adapter->getMetadata(NativeUnionEntity::class)
@@ -257,6 +272,31 @@ final class EntityAdapterTest extends TestCase
 				],
 			],
 			$adapter->getMetadata(NativeIntersectionEntity::class)
+		);
+	}
+
+	public function testMixedEntity(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->skip();
+		}
+
+		$adapter = new EntityAdapter();
+		Assert::same(
+			[
+				'type' => 'object',
+				'properties' => [
+					'mixed' => ['nullable' => true],
+					'complexType' => [
+						'anyOf' => [
+							['type' => 'array', 'items' => ['type' => 'string']],
+							['type' => 'array', 'items' => ['type' => 'integer']],
+							['type' => 'array', 'items' => ['type' => 'number']],
+						],
+					],
+				],
+			],
+			$adapter->getMetadata(MixedEntity::class)
 		);
 	}
 

--- a/tests/Fixtures/ResponseEntity/MixedEntity.php
+++ b/tests/Fixtures/ResponseEntity/MixedEntity.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\ResponseEntity;
+
+class MixedEntity
+{
+
+	public mixed $mixed;
+
+	/** @var string[]|(int[]&float[]) */
+	public mixed $complexType;
+
+}

--- a/tests/Fixtures/ResponseEntity/NativeUnionEntity.php
+++ b/tests/Fixtures/ResponseEntity/NativeUnionEntity.php
@@ -13,4 +13,9 @@ class NativeUnionEntity
 
 	public DateTime|int $dateOrInt;
 
+	public array|int $arrayOrInt;
+
+	/** @var string[]|string */
+	public array|string $strings;
+
 }

--- a/tests/Fixtures/ResponseEntity/TypedResponseEntity.php
+++ b/tests/Fixtures/ResponseEntity/TypedResponseEntity.php
@@ -23,4 +23,9 @@ class TypedResponseEntity
 	// phpcs:ignore
 	public $untypedProperty;
 
+	public array $untypedArray;
+
+	/** @var int[] */
+	public array $arrayOfInt;
+
 }


### PR DESCRIPTION
Fixes broken type extraction when property used native `array` or `mixed` type