### PR TITLE
OpenAPI: fix security scheme entity, add OAuth flow entity

### DIFF
--- a/src/OpenApi/Schema/Callback.php
+++ b/src/OpenApi/Schema/Callback.php
@@ -6,7 +6,7 @@ class Callback
 {
 
 	/** @var mixed[] */
-	private $data = [];
+	private array $data = [];
 
 	/**
 	 * @param mixed[] $data

--- a/src/OpenApi/Schema/Components.php
+++ b/src/OpenApi/Schema/Components.php
@@ -6,31 +6,31 @@ class Components
 {
 
 	/** @var Schema[]|Reference[] */
-	private $schemas = [];
+	private array $schemas = [];
 
 	/** @var Response[]|Reference[] */
-	private $responses = [];
+	private array $responses = [];
 
 	/** @var Parameter[]|Reference[] */
-	private $parameters = [];
+	private array $parameters = [];
 
 	/** @var Example[]|Reference[] */
-	private $examples = [];
+	private array $examples = [];
 
 	/** @var RequestBody[]|Reference[] */
-	private $requestBodies = [];
+	private array $requestBodies = [];
 
 	/** @var Header[]|Reference[] */
-	private $headers = [];
+	private array $headers = [];
 
 	/** @var SecurityScheme[]|Reference[] */
-	private $securitySchemes = [];
+	private array $securitySchemes = [];
 
 	/** @var Link[]|Reference[] */
-	private $links = [];
+	private array $links = [];
 
 	/** @var Callback[]|Reference[] */
-	private $callbacks = [];
+	private array $callbacks = [];
 
 	/**
 	 * @param mixed[] $data
@@ -53,6 +53,12 @@ class Components
 		if (isset($data['parameters'])) {
 			foreach ($data['parameters'] as $parameterKey => $parameterData) {
 				$components->setParameter($parameterKey, Parameter::fromArray($parameterData));
+			}
+		}
+
+		if (isset($data['examples'])) {
+			foreach ($data['examples'] as $exampleKey => $exampleData) {
+				$components->setExample($exampleKey, Example::fromArray($exampleData));
 			}
 		}
 
@@ -102,6 +108,14 @@ class Components
 	}
 
 	/**
+	 * @param Example|Reference $example
+	 */
+	public function setExample(string $name, $example): void
+	{
+		$this->examples[$name] = $example;
+	}
+
+	/**
 	 * @param RequestBody|Reference $requestBody
 	 */
 	public function setRequestBody(string $name, $requestBody): void
@@ -141,6 +155,10 @@ class Components
 
 		foreach ($this->parameters as $parameterKey => $parameter) {
 			$data['parameters'][$parameterKey] = $parameter->toArray();
+		}
+
+		foreach ($this->examples as $exampleKey => $example) {
+			$data['examples'][$exampleKey] = $example->toArray();
 		}
 
 		foreach ($this->requestBodies as $requestBodyKey => $requestBody) {

--- a/src/OpenApi/Schema/Contact.php
+++ b/src/OpenApi/Schema/Contact.php
@@ -6,13 +6,13 @@ class Contact
 {
 
 	/** @var string|null */
-	private $name;
+	private ?string $name = null;
 
 	/** @var string|null */
-	private $url;
+	private ?string $url = null;
 
 	/** @var string|null */
-	private $email;
+	private ?string $email = null;
 
 	/**
 	 * @return mixed[]

--- a/src/OpenApi/Schema/Example.php
+++ b/src/OpenApi/Schema/Example.php
@@ -5,12 +5,116 @@ namespace Apitte\OpenApi\Schema;
 class Example
 {
 
+	private ?string $summary = null;
+
+	private ?string $description = null;
+
+	/** @var mixed|null */
+	private $value = null;
+
+	private ?string $externalValue = null;
+
+	/**
+	 * @param mixed[] $data
+	 * @return self
+	 */
+	public static function fromArray(array $data): self
+	{
+		$example = new Example();
+		$example->summary = $data['summary'] ?? null;
+		$example->description = $data['description'] ?? null;
+		$example->value = $data['value'] ?? null;
+		$example->externalValue = $data['externalValue'] ?? null;
+		return $example;
+	}
+
 	/**
 	 * @return mixed[]
 	 */
 	public function toArray(): array
 	{
-		return [];
+		$data = [];
+		if ($this->summary !== null) {
+			$data['summary'] = $this->summary;
+		}
+
+		if ($this->description !== null) {
+			$data['description'] = $this->description;
+		}
+
+		if ($this->value !== null) {
+			$data['value'] = $this->value;
+		}
+
+		if ($this->externalValue !== null) {
+			$data['externalValue'] = $this->externalValue;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getSummary(): ?string
+	{
+		return $this->summary;
+	}
+
+	/**
+	 * @param string|null $summary
+	 */
+	public function setSummary(?string $summary): void
+	{
+		$this->summary = $summary;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getDescription(): ?string
+	{
+		return $this->description;
+	}
+
+	/**
+	 * @param string|null $description
+	 */
+	public function setDescription(?string $description): void
+	{
+		$this->description = $description;
+	}
+
+	/**
+	 * @return mixed|null
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+	/**
+	 * @param mixed|null $value
+	 */
+	public function setValue($value): void
+	{
+		$this->value = $value;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getExternalValue(): ?string
+	{
+		return $this->externalValue;
+	}
+
+	/**
+	 * @param string|null $externalValue
+	 */
+	public function setExternalValue(?string $externalValue): void
+	{
+		$this->externalValue = $externalValue;
 	}
 
 }

--- a/src/OpenApi/Schema/ExternalDocumentation.php
+++ b/src/OpenApi/Schema/ExternalDocumentation.php
@@ -6,10 +6,10 @@ class ExternalDocumentation
 {
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var string */
-	private $url;
+	private string $url;
 
 	public function __construct(string $url)
 	{

--- a/src/OpenApi/Schema/Header.php
+++ b/src/OpenApi/Schema/Header.php
@@ -6,10 +6,10 @@ class Header
 {
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var Schema|Reference|null */
-	private $schema;
+	private $schema = null;
 
 	/**
 	 * @param mixed[] $data

--- a/src/OpenApi/Schema/Info.php
+++ b/src/OpenApi/Schema/Info.php
@@ -6,22 +6,22 @@ class Info
 {
 
 	/** @var string */
-	private $title;
+	private string $title;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var string|null */
-	private $termsOfService;
+	private ?string $termsOfService = null;
 
 	/** @var Contact|null */
-	private $contact;
+	private ?Contact $contact = null;
 
 	/** @var License|null */
-	private $license;
+	private ?License $license = null;
 
 	/** @var string */
-	private $version;
+	private string $version;
 
 	public function __construct(string $title, string $version)
 	{

--- a/src/OpenApi/Schema/License.php
+++ b/src/OpenApi/Schema/License.php
@@ -6,10 +6,10 @@ class License
 {
 
 	/** @var string */
-	private $name;
+	private string $name;
 
 	/** @var string|null */
-	private $url;
+	private ?string $url = null;
 
 	public function __construct(string $name)
 	{

--- a/src/OpenApi/Schema/OAuthFlow.php
+++ b/src/OpenApi/Schema/OAuthFlow.php
@@ -15,7 +15,7 @@ class OAuthFlow
 	private string $refreshUrl;
 
 	/** @var array<string, string> */
-	private array $scopes;
+	private array $scopes = [];
 
 	/**
 	 * @param string $authorizationUrl

--- a/src/OpenApi/Schema/OAuthFlow.php
+++ b/src/OpenApi/Schema/OAuthFlow.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\OpenApi\Schema;
+
+class OAuthFlow
+{
+
+	/** @var string */
+	private string $authorizationUrl;
+
+	/** @var string */
+	private string $tokenUrl;
+
+	/** @var string */
+	private string $refreshUrl;
+
+	/** @var array<string, string> */
+	private array $scopes;
+
+	/**
+	 * @param string $authorizationUrl
+	 * @param string $tokenUrl
+	 * @param string $refreshUrl
+	 * @param array<string, string> $scopes
+	 */
+	public function __construct(string $authorizationUrl, string $tokenUrl, string $refreshUrl, array $scopes)
+	{
+		$this->authorizationUrl = $authorizationUrl;
+		$this->tokenUrl = $tokenUrl;
+		$this->refreshUrl = $refreshUrl;
+		$this->scopes = $scopes;
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	public function toArray(): array
+	{
+		return [
+			'authorizationUrl' => $this->authorizationUrl,
+			'tokenUrl' => $this->tokenUrl,
+			'refreshUrl' => $this->refreshUrl,
+			'scopes' => $this->scopes,
+		];
+	}
+
+	/**
+	 * @param mixed[] $data
+	 * @return self
+	 */
+	public static function fromArray(array $data): self
+	{
+		return new self(
+			$data['authorizationUrl'],
+			$data['tokenUrl'],
+			$data['refreshUrl'],
+			$data['scopes'],
+		);
+	}
+
+	public function getAuthorizationUrl(): string
+	{
+		return $this->authorizationUrl;
+	}
+
+	public function setAuthorizationUrl(string $authorizationUrl): void
+	{
+		$this->authorizationUrl = $authorizationUrl;
+	}
+
+	public function getTokenUrl(): string
+	{
+		return $this->tokenUrl;
+	}
+
+	public function setTokenUrl(string $tokenUrl): void
+	{
+		$this->tokenUrl = $tokenUrl;
+	}
+
+	public function getRefreshUrl(): string
+	{
+		return $this->refreshUrl;
+	}
+
+	public function setRefreshUrl(string $refreshUrl): void
+	{
+		$this->refreshUrl = $refreshUrl;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getScopes(): array
+	{
+		return $this->scopes;
+	}
+
+	/**
+	 * @param array<string, string> $scopes
+	 */
+	public function setScopes(array $scopes): void
+	{
+		$this->scopes = $scopes;
+	}
+
+}

--- a/src/OpenApi/Schema/OpenApi.php
+++ b/src/OpenApi/Schema/OpenApi.php
@@ -6,28 +6,28 @@ class OpenApi
 {
 
 	/** @var string */
-	private $openapi;
+	private string $openapi;
 
 	/** @var Info */
-	private $info;
+	private Info $info;
 
 	/** @var Server[] */
-	private $servers = [];
+	private array $servers = [];
 
 	/** @var Paths */
-	private $paths;
+	private Paths $paths;
 
 	/** @var Components|null */
-	private $components;
+	private ?Components $components = null;
 
 	/** @var SecurityRequirement[] */
-	private $security = [];
+	private array $security = [];
 
 	/** @var Tag[] */
-	private $tags = [];
+	private array $tags = [];
 
 	/** @var ExternalDocumentation|null */
-	private $externalDocs;
+	private ?ExternalDocumentation $externalDocs = null;
 
 	public function __construct(string $openapi, Info $info, Paths $paths)
 	{

--- a/src/OpenApi/Schema/Operation.php
+++ b/src/OpenApi/Schema/Operation.php
@@ -6,40 +6,40 @@ class Operation
 {
 
 	/** @var string[] */
-	private $tags = [];
+	private array $tags = [];
 
 	/** @var string|null */
-	private $summary;
+	private ?string $summary = null;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var ExternalDocumentation|null */
-	private $externalDocs;
+	private ?ExternalDocumentation $externalDocs = null;
 
 	/** @var string|null */
-	private $operationId;
+	private ?string $operationId = null;
 
 	/** @var Parameter[]|Reference[] */
-	private $parameters = [];
+	private array $parameters = [];
 
 	/** @var RequestBody|Reference|null */
-	private $requestBody;
+	private $requestBody = null;
 
 	/** @var Responses */
-	private $responses;
+	private Responses $responses;
 
 	/** @var Callback[]|Reference[] */
-	private $callbacks = [];
+	private array $callbacks = [];
 
 	/** @var bool */
-	private $deprecated = false;
+	private bool $deprecated = false;
 
 	/** @var SecurityRequirement[] */
-	private $security = [];
+	private array $security = [];
 
 	/** @var Server[] */
-	private $servers = [];
+	private array $servers = [];
 
 	public function __construct(Responses $responses)
 	{

--- a/src/OpenApi/Schema/Parameter.php
+++ b/src/OpenApi/Schema/Parameter.php
@@ -21,22 +21,22 @@ class Parameter
 	];
 
 	/** @var string */
-	private $name;
+	private string $name;
 
 	/** @var string */
-	private $in;
+	private string $in;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var bool */
-	private $required = false;
+	private bool $required = false;
 
 	/** @var bool */
-	private $deprecated = false;
+	private bool $deprecated = false;
 
 	/** @var bool */
-	private $allowEmptyValue = false;
+	private bool $allowEmptyValue = false;
 
 	/** @var Schema|Reference|null */
 	private $schema;
@@ -45,7 +45,7 @@ class Parameter
 	private $example;
 
 	/** @var string|null */
-	private $style;
+	private ?string $style = null;
 
 	public function __construct(string $name, string $in)
 	{

--- a/src/OpenApi/Schema/PathItem.php
+++ b/src/OpenApi/Schema/PathItem.php
@@ -16,7 +16,7 @@ class PathItem
 		OPERATION_TRACE = 'trace';
 
 	/** @var string[] */
-	private static $allowedOperations = [
+	private static array $allowedOperations = [
 		self::OPERATION_GET,
 		self::OPERATION_PUT,
 		self::OPERATION_POST,
@@ -28,19 +28,19 @@ class PathItem
 	];
 
 	/** @var string|null */
-	private $ref;
+	private ?string $ref = null;
 
 	/** @var string|null */
-	private $summary;
+	private ?string $summary = null;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var Operation[] */
-	private $operations = [];
+	private array $operations = [];
 
 	/** @var Server[] */
-	private $servers = [];
+	private array $servers = [];
 
 	/** @var Parameter|Reference */
 	private $params;

--- a/src/OpenApi/Schema/Paths.php
+++ b/src/OpenApi/Schema/Paths.php
@@ -6,7 +6,7 @@ class Paths
 {
 
 	/** @var PathItem[] */
-	private $paths = [];
+	private array $paths = [];
 
 	/**
 	 * @return mixed[]
@@ -41,7 +41,7 @@ class Paths
 
 	public function getPath(string $path): ?PathItem
 	{
-		return array_key_exists($path, $this->paths) ? $this->paths[$path] : null;
+		return $this->paths[$path] ?? null;
 	}
 
 }

--- a/src/OpenApi/Schema/Reference.php
+++ b/src/OpenApi/Schema/Reference.php
@@ -6,7 +6,7 @@ class Reference
 {
 
 	/** @var string */
-	private $ref;
+	private string $ref;
 
 	public function __construct(string $ref)
 	{

--- a/src/OpenApi/Schema/RequestBody.php
+++ b/src/OpenApi/Schema/RequestBody.php
@@ -6,13 +6,13 @@ class RequestBody
 {
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var MediaType[] */
-	private $content = [];
+	private array $content = [];
 
 	/** @var bool */
-	private $required = false;
+	private bool $required = false;
 
 	/**
 	 * @param mixed[] $data
@@ -44,7 +44,7 @@ class RequestBody
 			$data['content'][$key] = $mediaType->toArray();
 		}
 
-		if ($this->required === true) {
+		if ($this->required) {
 			$data['required'] = true;
 		}
 

--- a/src/OpenApi/Schema/Response.php
+++ b/src/OpenApi/Schema/Response.php
@@ -6,16 +6,16 @@ class Response
 {
 
 	/** @var string */
-	private $description;
+	private string $description;
 
 	/** @var Header[]|Reference[] */
-	private $headers = [];
+	private array $headers = [];
 
 	/** @var MediaType[] */
-	private $content = [];
+	private array $content = [];
 
 	/** @var Link[]|Reference[] */
-	private $links = [];
+	private array $links = [];
 
 	public function __construct(string $description)
 	{

--- a/src/OpenApi/Schema/Responses.php
+++ b/src/OpenApi/Schema/Responses.php
@@ -6,7 +6,7 @@ class Responses
 {
 
 	/** @var Response[]|Reference[] */
-	private $responses = [];
+	private array $responses = [];
 
 	/**
 	 * @param Response|Reference $response

--- a/src/OpenApi/Schema/Schema.php
+++ b/src/OpenApi/Schema/Schema.php
@@ -6,7 +6,7 @@ class Schema
 {
 
 	/** @var mixed[] */
-	private $data = [];
+	private array $data = [];
 
 	/**
 	 * @param mixed[] $data

--- a/src/OpenApi/Schema/SecurityRequirement.php
+++ b/src/OpenApi/Schema/SecurityRequirement.php
@@ -6,7 +6,7 @@ class SecurityRequirement
 {
 
 	/** @var mixed[] */
-	private $data;
+	private array $data = [];
 
 	/**
 	 * @param mixed[] $data

--- a/src/OpenApi/Schema/SecurityScheme.php
+++ b/src/OpenApi/Schema/SecurityScheme.php
@@ -2,36 +2,69 @@
 
 namespace Apitte\OpenApi\Schema;
 
+use Apitte\Core\Exception\Logical\InvalidArgumentException;
+
 class SecurityScheme
 {
+
+	public const
+		TYPE_API_KEY = 'apiKey',
+		TYPE_HTTP = 'http',
+		TYPE_OAUTH2 = 'oauth2',
+		TYPE_OPEN_ID_CONNECT = 'openIdConnect';
+
+	public const TYPES = [
+		self::TYPE_API_KEY,
+		self::TYPE_HTTP,
+		self::TYPE_OAUTH2,
+		self::TYPE_OPEN_ID_CONNECT,
+	];
+
+	public const
+		IN_COOKIE = 'cookie',
+		IN_HEADER = 'header',
+		IN_QUERY = 'query';
+
+	public const INS = [
+		self::IN_COOKIE,
+		self::IN_HEADER,
+		self::IN_QUERY,
+	];
+
+	public const FLOWS = [
+		'implicit',
+		'password',
+		'clientCredentials',
+		'authorizationCode',
+	];
 
 	/** @var string */
 	private string $type;
 
 	/** @var string|null */
-	private ?string $name;
+	private ?string $name = null;
 
 	/** @var string|null */
-	private ?string $description;
+	private ?string $description = null;
 
 	/** @var string|null */
-	private ?string $in;
+	private ?string $in = null;
 
 	/** @var string|null */
-	private ?string $template;
+	private ?string $scheme = null;
 
 	/** @var string|null */
-	private ?string $scheme;
-
-	/** @var string|null */
-	private ?string $bearerFormat;
+	private ?string $bearerFormat = null;
 
 	/** @var array<string, OAuthFlow> */
-	private array $flows;
+	private array $flows = [];
+
+	/** @var string|null */
+	private ?string $openIdConnectUrl = null;
 
 	public function __construct(string $type)
 	{
-		$this->type = $type;
+		$this->setType($type);
 	}
 
 	/**
@@ -53,10 +86,6 @@ class SecurityScheme
 			$data['in'] = $this->in;
 		}
 
-		if ($this->template !== null) {
-			$data['template'] = $this->template;
-		}
-
 		if ($this->scheme !== null) {
 			$data['scheme'] = $this->scheme;
 		}
@@ -66,7 +95,11 @@ class SecurityScheme
 		}
 
 		if (count($this->flows) > 0) {
-			$data['flows'] = $this->flows;
+			$data['flows'] = array_map(fn(OAuthFlow $flow) => $flow->toArray(), $this->flows);
+		}
+
+		if ($this->openIdConnectUrl !== null) {
+			$data['openIdConnectUrl'] = $this->openIdConnectUrl;
 		}
 
 		return $data;
@@ -77,14 +110,15 @@ class SecurityScheme
 	 */
 	public static function fromArray(array $data): SecurityScheme
 	{
-		$securityScheme = new SecurityScheme($data['type']);
+		$type = $data['type'];
+		$securityScheme = new SecurityScheme($type);
 		$securityScheme->setName($data['name'] ?? null);
 		$securityScheme->setDescription($data['description'] ?? null);
 		$securityScheme->setIn($data['in'] ?? null);
-		$securityScheme->setTemplate($data['template'] ?? null);
 		$securityScheme->setScheme($data['scheme'] ?? null);
 		$securityScheme->setBearerFormat($data['bearerFormat'] ?? null);
 		$securityScheme->setFlows(array_map(fn(array $flow) => OAuthFlow::fromArray($flow), $data['flows'] ?? []));
+		$securityScheme->setOpenIdConnectUrl($data['openIdConnectUrl'] ?? null);
 		return $securityScheme;
 	}
 
@@ -95,6 +129,14 @@ class SecurityScheme
 
 	public function setType(string $type): void
 	{
+		if (!in_array($type, self::TYPES, true)) {
+			throw new InvalidArgumentException(sprintf(
+				'Invalid value "%s" for attribute "type" given. It must be one of "%s".',
+				$type,
+				implode(', ', self::TYPES)
+			));
+		}
+
 		$this->type = $type;
 	}
 
@@ -105,6 +147,10 @@ class SecurityScheme
 
 	public function setName(?string $name): void
 	{
+		if ($this->type === self::TYPE_API_KEY && $name === null) {
+			throw new InvalidArgumentException('Attribute "name" is required for type "apiKey".');
+		}
+
 		$this->name = $name;
 	}
 
@@ -125,17 +171,20 @@ class SecurityScheme
 
 	public function setIn(?string $in): void
 	{
-		$this->in = $in;
-	}
+		if ($this->type === self::TYPE_API_KEY && $in === null) {
+			throw new InvalidArgumentException('Attribute "in" is required for type "apiKey".');
+		}
 
-	public function getTemplate(): ?string
-	{
-		return $this->template;
-	}
+		if ($in === null || in_array($in, self::INS, true)) {
+			$this->in = $in;
+			return;
+		}
 
-	public function setTemplate(?string $template): void
-	{
-		$this->template = $template;
+		throw new InvalidArgumentException(sprintf(
+			'Invalid value "%s" for attribute "in" given. It must be one of "%s".',
+			$in,
+			implode(', ', self::INS)
+		));
 	}
 
 	public function getScheme(): ?string
@@ -145,6 +194,10 @@ class SecurityScheme
 
 	public function setScheme(?string $scheme): void
 	{
+		if ($this->type === self::TYPE_HTTP && $scheme === null) {
+			throw new InvalidArgumentException('Attribute "scheme" is required for type "http".');
+		}
+
 		$this->scheme = $scheme;
 	}
 
@@ -155,6 +208,10 @@ class SecurityScheme
 
 	public function setBearerFormat(?string $bearerFormat): void
 	{
+		if ($this->type === self::TYPE_HTTP && $this->scheme === 'bearer' && $bearerFormat === null) {
+			throw new InvalidArgumentException('Attribute "bearerFormat" is required for type "http" and scheme "bearer".');
+		}
+
 		$this->bearerFormat = $bearerFormat;
 	}
 
@@ -171,7 +228,36 @@ class SecurityScheme
 	 */
 	public function setFlows(array $flows): void
 	{
+		if ($this->type === self::TYPE_OAUTH2 && count($flows) === 0) {
+			throw new InvalidArgumentException('Attribute "flows" is required for type "oauth2".');
+		}
+
+		if ($this->type === self::TYPE_OAUTH2) {
+			foreach (self::FLOWS as $flow) {
+				if (!array_key_exists($flow, $flows)) {
+					throw new InvalidArgumentException(sprintf(
+						'Attribute "flows" is missing required key "%s".',
+						$flow
+					));
+				}
+			}
+		}
+
 		$this->flows = $flows;
+	}
+
+	public function getOpenIdConnectUrl(): ?string
+	{
+		return $this->openIdConnectUrl;
+	}
+
+	public function setOpenIdConnectUrl(?string $openIdConnectUrl): void
+	{
+		if ($this->type === self::TYPE_OPEN_ID_CONNECT && $openIdConnectUrl === null) {
+			throw new InvalidArgumentException('Attribute "openIdConnectUrl" is required for type "openIdConnect".');
+		}
+
+		$this->openIdConnectUrl = $openIdConnectUrl;
 	}
 
 }

--- a/src/OpenApi/Schema/SecurityScheme.php
+++ b/src/OpenApi/Schema/SecurityScheme.php
@@ -6,28 +6,28 @@ class SecurityScheme
 {
 
 	/** @var string */
-	private $type;
+	private string $type;
 
 	/** @var string|null */
-	private $name;
+	private ?string $name;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description;
 
 	/** @var string|null */
-	private $in;
+	private ?string $in;
 
 	/** @var string|null */
-	private $template;
+	private ?string $template;
 
 	/** @var string|null */
-	private $scheme;
+	private ?string $scheme;
 
 	/** @var string|null */
-	private $bearerFormat;
+	private ?string $bearerFormat;
 
-	/** @var mixed[] */
-	private $flows;
+	/** @var array<string, OAuthFlow> */
+	private array $flows;
 
 	public function __construct(string $type)
 	{
@@ -84,7 +84,7 @@ class SecurityScheme
 		$securityScheme->setTemplate($data['template'] ?? null);
 		$securityScheme->setScheme($data['scheme'] ?? null);
 		$securityScheme->setBearerFormat($data['bearerFormat'] ?? null);
-		$securityScheme->setFlows($data['flows'] ?? []);
+		$securityScheme->setFlows(array_map(fn(array $flow) => OAuthFlow::fromArray($flow), $data['flows'] ?? []));
 		return $securityScheme;
 	}
 
@@ -158,12 +158,18 @@ class SecurityScheme
 		$this->bearerFormat = $bearerFormat;
 	}
 
-	public function getFlows(): mixed
+	/**
+	 * @return array<string, OAuthFlow>
+	 */
+	public function getFlows(): array
 	{
 		return $this->flows;
 	}
 
-	public function setFlows(mixed $flows): void
+	/**
+	 * @param array<string, OAuthFlow> $flows
+	 */
+	public function setFlows(array $flows): void
 	{
 		$this->flows = $flows;
 	}

--- a/src/OpenApi/Schema/SecurityScheme.php
+++ b/src/OpenApi/Schema/SecurityScheme.php
@@ -94,8 +94,8 @@ class SecurityScheme
 			$data['bearerFormat'] = $this->bearerFormat;
 		}
 
-		if (count($this->flows) > 0) {
-			$data['flows'] = array_map(fn(OAuthFlow $flow) => $flow->toArray(), $this->flows);
+		if ($this->flows !== []) {
+			$data['flows'] = array_map(static fn(OAuthFlow $flow): array => $flow->toArray(), $this->flows);
 		}
 
 		if ($this->openIdConnectUrl !== null) {
@@ -117,7 +117,7 @@ class SecurityScheme
 		$securityScheme->setIn($data['in'] ?? null);
 		$securityScheme->setScheme($data['scheme'] ?? null);
 		$securityScheme->setBearerFormat($data['bearerFormat'] ?? null);
-		$securityScheme->setFlows(array_map(fn(array $flow) => OAuthFlow::fromArray($flow), $data['flows'] ?? []));
+		$securityScheme->setFlows(array_map(static fn(array $flow): OAuthFlow => OAuthFlow::fromArray($flow), $data['flows'] ?? []));
 		$securityScheme->setOpenIdConnectUrl($data['openIdConnectUrl'] ?? null);
 		return $securityScheme;
 	}
@@ -228,7 +228,7 @@ class SecurityScheme
 	 */
 	public function setFlows(array $flows): void
 	{
-		if ($this->type === self::TYPE_OAUTH2 && count($flows) === 0) {
+		if ($this->type === self::TYPE_OAUTH2 && $flows === []) {
 			throw new InvalidArgumentException('Attribute "flows" is required for type "oauth2".');
 		}
 

--- a/src/OpenApi/Schema/Server.php
+++ b/src/OpenApi/Schema/Server.php
@@ -6,13 +6,13 @@ class Server
 {
 
 	/** @var string */
-	private $url;
+	private string $url;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var ServerVariable[] */
-	private $variables = [];
+	private array $variables = [];
 
 	public function __construct(string $url)
 	{

--- a/src/OpenApi/Schema/ServerVariable.php
+++ b/src/OpenApi/Schema/ServerVariable.php
@@ -6,13 +6,13 @@ class ServerVariable
 {
 
 	/** @var string[] */
-	private $enum = [];
+	private array $enum = [];
 
 	/** @var string */
-	private $default;
+	private string $default;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	public function __construct(string $default)
 	{

--- a/src/OpenApi/Schema/Tag.php
+++ b/src/OpenApi/Schema/Tag.php
@@ -6,13 +6,13 @@ class Tag
 {
 
 	/** @var string */
-	private $name;
+	private string $name;
 
 	/** @var string|null */
-	private $description;
+	private ?string $description = null;
 
 	/** @var ExternalDocumentation|null */
-	private $externalDocs;
+	private ?ExternalDocumentation $externalDocs = null;
 
 	public function __construct(string $name)
 	{

--- a/tests/Cases/OpenApi/Schema/ExampleTest.php
+++ b/tests/Cases/OpenApi/Schema/ExampleTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\OpenApi\Cases\Schema;
+
+use Apitte\OpenApi\Schema\Example;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+class ExampleTest extends TestCase
+{
+
+	public function testAll(): void
+	{
+		$example = new Example();
+		$summary = 'Summary';
+		$description = 'Description';
+		$value = 'Value';
+		$externalValue = 'ExternalValue';
+		$example->setSummary($summary);
+		$example->setDescription($description);
+		$example->setValue($value);
+		$example->setExternalValue($externalValue);
+
+		Assert::same($summary, $example->getSummary());
+		Assert::same($description, $example->getDescription());
+		Assert::same($value, $example->getValue());
+		Assert::same($externalValue, $example->getExternalValue());
+
+		$realData = $example->toArray();
+		$expectedData = [
+			'summary' => $summary,
+			'description' => $description,
+			'value' => $value,
+			'externalValue' => $externalValue,
+		];
+
+		Assert::same($expectedData, $realData);
+		Assert::same($expectedData, Example::fromArray($realData)->toArray());
+	}
+
+}
+
+(new ExampleTest())->run();

--- a/tests/Cases/OpenApi/Schema/ExamplesTest.php
+++ b/tests/Cases/OpenApi/Schema/ExamplesTest.php
@@ -21,11 +21,10 @@ final class ExamplesTest extends TestCase
 
 	public function testApiWithExamples(): void
 	{
-		// TODO examples
-		//$rawData = Yaml::parseFile(__DIR__ . '/examples/api-with-examples.yaml');
-		//$openApi = OpenApi::fromArray($rawData);
-		//$openApiData = $openApi->toArray();
-		//self::assertSameDataStructure($rawData, $openApiData);
+		$rawData = Yaml::parseFile(__DIR__ . '/examples/api-with-examples.yaml');
+		$openApi = OpenApi::fromArray($rawData);
+		$openApiData = $openApi->toArray();
+		self::assertSameDataStructure($rawData, $openApiData);
 	}
 
 	public function testCallbackExample(): void
@@ -64,10 +63,10 @@ final class ExamplesTest extends TestCase
 
 	public function testUspto(): void
 	{
-		//$rawData = Yaml::parseFile(__DIR__ . '/examples/uspto.yaml');
-		//$openApi = OpenApi::fromArray($rawData);
-		//$openApiData = $openApi->toArray();
-		//self::assertSameDataStructure($rawData, $openApiData);
+		$rawData = Yaml::parseFile(__DIR__ . '/examples/uspto.yaml');
+		$openApi = OpenApi::fromArray($rawData);
+		$openApiData = $openApi->toArray();
+		self::assertSameDataStructure($rawData, $openApiData);
 	}
 
 	/**

--- a/tests/Cases/OpenApi/Schema/OAuthFlowTest.php
+++ b/tests/Cases/OpenApi/Schema/OAuthFlowTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\OpenApi\Cases\Schema;
+
+use Apitte\OpenApi\Schema\OAuthFlow;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+class OAuthFlowTest extends TestCase
+{
+
+	public function testRequired(): void
+	{
+		$authorizationUrl = 'https://example.com/authorization';
+		$tokenUrl = 'https://example.com/token';
+		$refreshUrl = 'https://example.com/refresh';
+		$scopes = ['read' => 'Read access', 'write' => 'Write access'];
+		$flow = new OAuthFlow($authorizationUrl, $tokenUrl, $refreshUrl, $scopes);
+
+		Assert::same($authorizationUrl, $flow->getAuthorizationUrl());
+		Assert::same($tokenUrl, $flow->getTokenUrl());
+		Assert::same($refreshUrl, $flow->getRefreshUrl());
+		Assert::same($scopes, $flow->getScopes());
+
+		$realData = $flow->toArray();
+		$expectedData = [
+			'authorizationUrl' => $authorizationUrl,
+			'tokenUrl' => $tokenUrl,
+			'refreshUrl' => $refreshUrl,
+			'scopes' => $scopes,
+		];
+
+		Assert::same($expectedData, $realData);
+		Assert::same($expectedData, OAuthFlow::fromArray($realData)->toArray());
+	}
+
+}
+
+(new OAuthFlowTest())->run();

--- a/tests/Cases/OpenApi/Schema/SecuritySchemeTest.php
+++ b/tests/Cases/OpenApi/Schema/SecuritySchemeTest.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\OpenApi\Cases\Schema;
+
+use Apitte\Core\Exception\Logical\InvalidArgumentException;
+use Apitte\OpenApi\Schema\SecurityScheme;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+class SecuritySchemeTest extends TestCase
+{
+
+	/**
+	 * @return mixed[][]
+	 */
+	public function getRequiredData(): array
+	{
+		return [
+			[
+				[
+					'type' => SecurityScheme::TYPE_API_KEY,
+					'name' => 'api_key',
+					'in' => SecurityScheme::IN_HEADER,
+				],
+			],
+			[
+				[
+					'type' => SecurityScheme::TYPE_HTTP,
+					'scheme' => 'basic',
+				],
+			],
+			[
+				[
+					'type' => SecurityScheme::TYPE_HTTP,
+					'scheme' => 'bearer',
+					'bearerFormat' => 'JWT',
+				],
+			],
+			[
+				[
+					'type' => SecurityScheme::TYPE_OAUTH2,
+					'flows' => [
+						'implicit' => [
+							'authorizationUrl' => 'https://example.com/authorization',
+							'tokenUrl' => 'https://example.com/token',
+							'refreshUrl' => 'https://example.com/refresh',
+							'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+						],
+						'password' => [
+							'authorizationUrl' => 'https://example.com/authorization',
+							'tokenUrl' => 'https://example.com/token',
+							'refreshUrl' => 'https://example.com/refresh',
+							'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+						],
+						'clientCredentials' => [
+							'authorizationUrl' => 'https://example.com/authorization',
+							'tokenUrl' => 'https://example.com/token',
+							'refreshUrl' => 'https://example.com/refresh',
+							'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+						],
+						'authorizationCode' => [
+							'authorizationUrl' => 'https://example.com/authorization',
+							'tokenUrl' => 'https://example.com/token',
+							'refreshUrl' => 'https://example.com/refresh',
+							'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+						],
+					],
+				],
+			],
+			[
+				[
+					'type' => SecurityScheme::TYPE_OPEN_ID_CONNECT,
+					'openIdConnectUrl' => 'https://example.com/.well-known/openid-configuration',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider getRequiredData
+	 * @param mixed[] $array
+	 */
+	public function testRequired(array $array): void
+	{
+		$securityScheme = SecurityScheme::fromArray($array);
+		Assert::same($array, $securityScheme->toArray());
+	}
+
+	public function testOptional(): void
+	{
+		$type = SecurityScheme::TYPE_API_KEY;
+		$name = 'api_key';
+		$in = SecurityScheme::IN_HEADER;
+		$description = 'API key';
+		$securityScheme = new SecurityScheme($type);
+		$securityScheme->setName($name);
+		$securityScheme->setIn($in);
+		$securityScheme->setDescription($description);
+
+		Assert::same($type, $securityScheme->getType());
+		Assert::same($name, $securityScheme->getName());
+		Assert::same($in, $securityScheme->getIn());
+		Assert::same($description, $securityScheme->getDescription());
+
+		$array = $securityScheme->toArray();
+		$expected = [
+			'type' => $type,
+			'name' => $name,
+			'description' => $description,
+			'in' => $in,
+		];
+		Assert::same($expected, $array);
+		Assert::same($expected, SecurityScheme::fromArray($array)->toArray());
+	}
+
+	public function testInvalidType(): void
+	{
+		Assert::exception(function () {
+			new SecurityScheme('invalid');
+		}, InvalidArgumentException::class, 'Invalid value "invalid" for attribute "type" given. It must be one of "apiKey, http, oauth2, openIdConnect".');
+	}
+
+
+	public function testMissingName(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_API_KEY);
+			$securityScheme->setIn(SecurityScheme::IN_HEADER);
+			$securityScheme->setName(null);
+		}, InvalidArgumentException::class, 'Attribute "name" is required for type "apiKey".');
+	}
+
+	public function testMissingIn(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_API_KEY);
+			$securityScheme->setName('api_key');
+			$securityScheme->setIn(null);
+		}, InvalidArgumentException::class, 'Attribute "in" is required for type "apiKey".');
+	}
+
+	public function testInvalidIn(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_API_KEY);
+			$securityScheme->setName('api_key');
+			$securityScheme->setIn('invalid');
+		}, InvalidArgumentException::class, 'Invalid value "invalid" for attribute "in" given. It must be one of "cookie, header, query".');
+	}
+
+	public function testMissingScheme(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_HTTP);
+			$securityScheme->setScheme(null);
+		}, InvalidArgumentException::class, 'Attribute "scheme" is required for type "http".');
+	}
+
+	public function testMissingBearerFormat(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_HTTP);
+			$securityScheme->setScheme('bearer');
+			$securityScheme->setBearerFormat(null);
+		}, InvalidArgumentException::class, 'Attribute "bearerFormat" is required for type "http" and scheme "bearer".');
+	}
+
+	public function testMissingFlows(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([]);
+		}, InvalidArgumentException::class, 'Attribute "flows" is required for type "oauth2".');
+	}
+
+	public function testMissingFlow(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OAUTH2);
+			$securityScheme->setFlows([
+				'implicit' => [
+					'authorizationUrl' => 'https://example.com/authorization',
+					'tokenUrl' => 'https://example.com/token',
+					'refreshUrl' => 'https://example.com/refresh',
+					'scopes' => ['read' => 'Read access', 'write' => 'Write access'],
+				],
+			]);
+		}, InvalidArgumentException::class, 'Attribute "flows" is missing required key "password".');
+	}
+
+	public function testMissingOpenIdConnectUrl(): void
+	{
+		Assert::exception(function () {
+			$securityScheme = new SecurityScheme(SecurityScheme::TYPE_OPEN_ID_CONNECT);
+			$securityScheme->setOpenIdConnectUrl(null);
+		}, InvalidArgumentException::class, 'Attribute "openIdConnectUrl" is required for type "openIdConnect".');
+	}
+
+}
+
+(new SecuritySchemeTest())->run();


### PR DESCRIPTION
Fixes `ERROR: Argument 1 passed to Apitte\OpenApi\Schema\SecurityScheme::setFlows() must be an instance of Apitte\OpenApi\Schema\mixed, array given, called in vendor/contributte/apitte/src/OpenApi/Schema/SecurityScheme.php on line 87`