### PR TITLE
ApiRequest: fix obtaining entity

### DIFF
--- a/src/Core/Http/ApiRequest.php
+++ b/src/Core/Http/ApiRequest.php
@@ -42,7 +42,7 @@ class ApiRequest extends ProxyRequest
 	{
 		$entity = $this->getAttribute(RequestAttributes::ATTR_REQUEST_ENTITY, null);
 
-		if ($entity !== null) {
+		if ($entity === null) {
 			if (func_num_args() < 1) {
 				throw new InvalidStateException('No request entity found');
 			}

--- a/tests/Cases/Core/Http/ApiRequest.phpt
+++ b/tests/Cases/Core/Http/ApiRequest.phpt
@@ -11,6 +11,15 @@ use Apitte\Core\Http\RequestAttributes;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 use Tester\Assert;
 
+// Entity
+test(function (): void {
+	$request = Psr7ServerRequestFactory::fromSuperGlobal();
+	$apiRequest = new ApiRequest($request);
+	$apiRequest = $apiRequest->withAttribute(RequestAttributes::ATTR_REQUEST_ENTITY, new stdClass());
+
+	Assert::type(stdClass::class, $apiRequest->getEntity());
+});
+
 // Parameters
 test(function (): void {
 	$request = Psr7ServerRequestFactory::fromSuperGlobal();


### PR DESCRIPTION
https://github.com/contributte/apitte/pull/191/files#diff-b8b31d40dde0855d1d14c2822f1d6bb10da7487817c9d953cb357e4d916a48cdL44-R45 introduced inverted condition for checking entity.