### PR TITLE
Merge endpoint parameters specification if OpenApi annotation is provided

### DIFF
--- a/tests/Cases/OpenApi/Schema/OperationTest.php
+++ b/tests/Cases/OpenApi/Schema/OperationTest.php
@@ -35,9 +35,9 @@ class OperationTest extends TestCase
 		$operation->setExternalDocs($externalDocs);
 
 		$parameters = [];
-		$parameters[] = $p1 = new Parameter('p1', Parameter::IN_PATH);
+		$parameters['path-p1'] = $p1 = new Parameter('p1', Parameter::IN_PATH);
 		$operation->addParameter($p1);
-		$parameters[] = $p2 = new Parameter('p2', Parameter::IN_COOKIE);
+		$parameters['cookie-p2'] = $p2 = new Parameter('p2', Parameter::IN_COOKIE);
 		$operation->addParameter($p2);
 		$parameters[] = $p3 = new Reference('r1');
 		$operation->addParameter($p3);


### PR DESCRIPTION
Example:

```php
	/**
	 * @Path("/")
	 * @Method("GET")
	 * @Tag(name="@authenticated", value="User")
	 *
	 * @RequestParameters({
	 *     @RequestParameter(name="filters", in="query", required=false, description="Filters", type="object"),
	 * })
	 *
	 * @RequestBody("\App\Api\Entity\Request\Employee\EmployeeList")
	 *
	 *
	 * @OpenApi("
	 *    summary: Get employees
	 *    operationId: getEmployees
	 *    tags:
	 *       - Employee
	 *    security:
	 *       - BearerAuth: []
	 *    parameters:
	 *     - in: query
	 *       name: filters
	 *       schema:
	 *         type: object
	 *         items:
	 *           type: string
	 *       style: deepObject
	 *       example: {'foo': 'bar'}
	 *    responses:
	 *       200:
	 *           description: Emploeey list
	 *           content:
	 *               application/json:
	 *                   example:
	 *       default:
	 *           description: unexpected error
	 * ")
     */
	public function getEmployees(ApiRequest $request, ApiResponse $response): ApiResponse
	{
		//...

		return $response->writeJsonBody([]);
	}
```

<img width="1447" alt="image" src="https://github.com/contributte/apitte/assets/2492578/6c69ee00-f02f-46ef-8603-f011d0129758">
