### PR TITLE
test: add failing tests :-(

### DIFF
--- a/tests/Cases/Core/Mapping/Validator/SymfonyValidator.phpt
+++ b/tests/Cases/Core/Mapping/Validator/SymfonyValidator.phpt
@@ -23,9 +23,19 @@ Toolkit::test(function (): void {
 
 	$entity = (new SimpleEntity())->factory(['id' => 1, 'typedId' => 'foo']);
 
-	Assert::exception(static function () use ($entity, $validator): void {
+	$e = Assert::exception(static function () use ($entity, $validator): void {
 		$validator->validate($entity);
 	}, ValidationException::class);
+
+	assert($e instanceof ValidationException);
+
+	Assert::same([
+		'validation' => [
+			'typedId' => [
+				'This value should be of type integer.',
+			],
+		],
+	], $e->getContext());
 });
 
 // Without annotation reader
@@ -34,9 +44,19 @@ Toolkit::test(function (): void {
 
 	$entity = (new SimpleEntity())->factory(['id' => null, 'typedId' => 'foo']);
 
-	Assert::exception(static function () use ($entity, $validator): void {
+	$e = Assert::exception(static function () use ($entity, $validator): void {
 		$validator->validate($entity);
 	}, ValidationException::class);
+
+	assert($e instanceof ValidationException);
+
+	Assert::same([
+		'validation' => [
+			'typedId' => [
+				'This value should be of type integer.',
+			],
+		],
+	], $e->getContext());
 
 	$entity = (new SimpleEntity())->factory(['id' => null, 'typedId' => 1]);
 


### PR DESCRIPTION
Ok, i switched to typed properties and found some bugs in SymfonyValidator,, i am not sure, how to fix it, maybe you will know?

```php
	#[Assert\NotNull]
	#[Assert\Type(type: 'integer')]
	public $typedId;
```

when you send `['typedId' => 'sss']` the validator throws `typeId` is not integer, but

```php
	#[Assert\NotNull]
	#[Assert\Type(type: 'integer')]
	public int $typedId;
```
throws `typedId` cannot be null...

This is real problem in nullable properties

```php
	#[Assert\Type(type: 'integer')]
	public ?int $typedId = null;
```
when you send ```['typedId' => 'sss']```, it will pass without any errors...
