### PR TITLE
replaced deprecated 'stream_for' method in docs

### DIFF
--- a/.docs/decorators.md
+++ b/.docs/decorators.md
@@ -94,7 +94,7 @@ use Apitte\Core\Decorator\IRequestDecorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 
 class RequestAuthenticationDecorator implements IRequestDecorator
 {
@@ -105,7 +105,7 @@ class RequestAuthenticationDecorator implements IRequestDecorator
     public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
     {
         if ($userAuthenticationFailed) {
-            $body = stream_for(json_encode([
+            $body = Utils::streamFor(json_encode([
                 'status' => 'error',
                 'code' => 403,
                 'message' => 'Invalid credentials, authentication failed.'


### PR DESCRIPTION
Hi,

while I was playing with Apitte I found a "bug/mistake" in the documentation.

It's about using the deprecated method "stream_for"

So I replaced it with what is recommended in the [GuzzleHttp documentation](https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.stream_for.html)